### PR TITLE
OWASP Speakeragreement...

### DIFF
--- a/cfp/index.html
+++ b/cfp/index.html
@@ -89,7 +89,7 @@
       Die Zusammenfassung sollte nicht weniger als 500 Zeichen lang sein. 
       (Bitte auf Orthographie achten, da die Zusammenfassung so, wie sie ist, ggf. im Programm erscheint). 
       Die gilt ebenso f&uuml;r die obligatorische Kurzbiographie (150–800 Zeichen). 
-      Die Pr&auml;sentationen werden voraussichtlich 20 oder 40 Minuten dauern, plus 5 Minuten Diskussion.
+      Die Pr&auml;sentationen werden voraussichtlich 20 oder 40 Minuten dauern, plus 5 Minuten Diskussion. Eine Präferenz kann gerne angegeben werden.
       Dar&uuml;ber hinaus wird es voraussichtlich einen Slot mit drei Lightningtalks (10 Minuten Vortrag, 2–5 Minuten Diskussion) geben.
     </p>
     <p>
@@ -111,9 +111,12 @@
       <li>Neues zu OWASP-Projekten </li>
     </ul>
     <p>
-      Folien der Vortr&auml;ge werden im Anschluss an die Konferenz unter der freien OWASP-Lizenz auf der Konferenzwebseite ver&ouml;ffentlicht. 
+      Folien der Vortr&auml;ge werden im Anschluss an die Konferenz unter einer freien Lizenz auf der Konferenzwebseite ver&ouml;ffentlicht. 
       Dar&uuml;ber hinaus werden alle Talks aufgezeichnet und im Anschluss <a href="https://www.youtube.com/channel/UCO7VtjaFHkfsDNZEFg9OssQ">auf dem YouTube Channel des German OWASP Chapter ver&ouml;ffentlicht</a>.
       Wer nicht aufgezeichnet werden will, m&ouml;ge das bitte in seiner Einreichung vermerken.
+    </p>
+    <p>
+      Sofern nicht anders auf der Webseite des German OWASP Days ausgedrückt (Speaker reimbursement) gilt für alle Einreicher das <a href="https://www.owasp.org/index.php/Speaker_Agreement" target="_blank">OWASP-Speakeragrement</a>
     </p>
 
     <p>


### PR DESCRIPTION
... ist die heilige Bibel von OWASP. Bitte nicht vergessen.

Wir wollen keine Firmenlogos oder andere Company Feautures auf den Slides.

Danke, Dirk

PS: "Suggested Licenses" sind unter https://www.owasp.org/index.php/OWASP_Licenses. Da fehlt noch ein Hinweis. Irgendwie kann ich aber mit meinem Browser gerade nicht den Commit ergänzen. --> Später oder gerne jemand anders