### PR TITLE
fixing geo location of conference and social event

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -8,8 +8,8 @@
 // }
 
 function initOSM(map) {
-  var center_conference = ol.proj.transform([7.611038,51.977210], 'EPSG:4326', 'EPSG:3857');
-  var center_evening_event = ol.proj.transform([7.611038,51.977210], 'EPSG:4326', 'EPSG:3857');
+  var center_conference = ol.proj.transform([8.40182,49.00770], 'EPSG:4326', 'EPSG:3857');
+  var center_evening_event = ol.proj.transform([8.39374,49.01206], 'EPSG:4326', 'EPSG:3857');
   var center = center_conference; // default
 
   if(map == "Evening Event"){


### PR DESCRIPTION
Pull request #20 fixed the open street map, though the fixed map displayed the coordinates of the previous event. This commit should point the map to the correct coordinates.