### PR TITLE
switching to new eventbrite event

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -45,7 +45,7 @@
         </ul>
 
         <ul class="nav navbar-nav navbar-right">
-          <li><a class="ticketbutton" href="https://www.eventbrite.com/e/german-owasp-day-2019-tickets-75721991515">Tickets</a></li>
+          <li><a class="ticketbutton" href="https://www.eventbrite.com/e/german-owasp-day-2019-karlsruhe-tickets-82951101979">Tickets</a></li>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Archiv <span class="caret"></span></a>
             <ul class="dropdown-menu">

--- a/cfp/index.html
+++ b/cfp/index.html
@@ -44,7 +44,7 @@
         </ul>
 
         <ul class="nav navbar-nav navbar-right">
-          <li><a class="ticketbutton" href="https://www.eventbrite.com/e/german-owasp-day-2019-tickets-75721991515">Tickets</a></li>
+          <li><a class="ticketbutton" href="https://www.eventbrite.com/e/german-owasp-day-2019-karlsruhe-tickets-82951101979">Tickets</a></li>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Archiv <span class="caret"></span></a>
             <ul class="dropdown-menu">

--- a/contact/index.html
+++ b/contact/index.html
@@ -44,7 +44,7 @@
         </ul>
 
         <ul class="nav navbar-nav navbar-right">
-          <li><a class="ticketbutton" href="https://www.eventbrite.com/e/german-owasp-day-2019-tickets-75721991515">Tickets</a></li>
+          <li><a class="ticketbutton" href="https://www.eventbrite.com/e/german-owasp-day-2019-karlsruhe-tickets-82951101979">Tickets</a></li>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Archiv <span class="caret"></span></a>
             <ul class="dropdown-menu">

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
         </ul>
 
         <ul class="nav navbar-nav navbar-right">
-          <li><a class="ticketbutton" href="https://www.eventbrite.com/e/german-owasp-day-2019-tickets-75721991515">Tickets</a></li>
+          <li><a class="ticketbutton" href="https://www.eventbrite.com/e/german-owasp-day-2019-karlsruhe-tickets-82951101979">Tickets</a></li>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Archiv <span class="caret"></span></a>
             <ul class="dropdown-menu">
@@ -68,7 +68,7 @@
     <div class="row">
       <div class="col-sm-8">
         <legend><h1>GERMAN OWASP DAY 2019</h1></legend>
-	<div class="alert alert-success">Unser Programm <a href="/schedule/">steht inzwischen</a> und <a href="https://www.eventbrite.com/e/german-owasp-day-2019-tickets-75721991515">der Ticketverkauf hat begonnen</a>! Folgt uns <a href="https://twitter.com/owasp_de">auf Twitter</a> oder subscribed <a href="https://groups.google.com/a/owasp.org/forum/#!forum/germany-chapter">auf der Mailingliste</a>, um immer auf dem neuesten Stand zu bleiben!</div>
+	<div class="alert alert-success">Unser Programm <a href="/schedule/">steht inzwischen</a> und <a href="https://www.eventbrite.com/e/german-owasp-day-2019-karlsruhe-tickets-82951101979">der Ticketverkauf hat begonnen</a>! Folgt uns <a href="https://twitter.com/owasp_de">auf Twitter</a> oder subscribed <a href="https://groups.google.com/a/owasp.org/forum/#!forum/germany-chapter">auf der Mailingliste</a>, um immer auf dem neuesten Stand zu bleiben!</div>
         <p>
           Das ​German ​Chapter ​des ​Open ​Web ​Application ​Security Project ​(OWASP) richtet jährlich ihre ​nationale ​OWASP-Konferenz ​aus.
         </p>

--- a/location/conference/index.html
+++ b/location/conference/index.html
@@ -49,7 +49,7 @@
         </ul>
 
         <ul class="nav navbar-nav navbar-right">
-          <li><a class="ticketbutton" href="https://www.eventbrite.com/e/german-owasp-day-2019-tickets-75721991515">Tickets</a></li>
+          <li><a class="ticketbutton" href="https://www.eventbrite.com/e/german-owasp-day-2019-karlsruhe-tickets-82951101979">Tickets</a></li>
           <li><a href="https://github.com/OWASP/german-owasp-day"><img class="social img-responsive" src="/img/icons/github.png"/></a></li>
         </ul>
       </div><!--/.nav-collapse -->

--- a/location/evening/index.html
+++ b/location/evening/index.html
@@ -49,7 +49,7 @@
         </ul>
 
         <ul class="nav navbar-nav navbar-right">
-          <li><a class="ticketbutton" href="https://www.eventbrite.com/e/german-owasp-day-2019-tickets-75721991515">Tickets</a></li>
+          <li><a class="ticketbutton" href="https://www.eventbrite.com/e/german-owasp-day-2019-karlsruhe-tickets-82951101979">Tickets</a></li>
           <li><a href="https://github.com/OWASP/german-owasp-day"><img class="social img-responsive" src="/img/icons/github.png"/></a></li>
         </ul>
       </div><!--/.nav-collapse -->

--- a/schedule/index.html
+++ b/schedule/index.html
@@ -46,7 +46,7 @@
         </ul>
 
         <ul class="nav navbar-nav navbar-right">
-          <li><a class="ticketbutton" href="https://www.eventbrite.com/e/german-owasp-day-2019-tickets-75721991515">Tickets</a></li>
+          <li><a class="ticketbutton" href="https://www.eventbrite.com/e/german-owasp-day-2019-karlsruhe-tickets-82951101979">Tickets</a></li>
           <li><a href="https://github.com/OWASP/german-owasp-day"><img class="social img-responsive" src="/img/icons/github.png"/></a></li>
         </ul>
       </div><!--/.nav-collapse -->

--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -44,7 +44,7 @@
         </ul>
 
         <ul class="nav navbar-nav navbar-right">
-          <li><a class="ticketbutton" href="https://www.eventbrite.com/e/german-owasp-day-2019-tickets-75721991515">Tickets</a></li>
+          <li><a class="ticketbutton" href="https://www.eventbrite.com/e/german-owasp-day-2019-karlsruhe-tickets-82951101979">Tickets</a></li>
           <li><a href="https://github.com/OWASP/german-owasp-day"><img class="social img-responsive" src="/img/icons/github.png"></img></a></li>
         </ul>
       </div><!--/.nav-collapse -->

--- a/tickets/index.html
+++ b/tickets/index.html
@@ -44,7 +44,7 @@
         </ul>
 
         <ul class="nav navbar-nav navbar-right">
-          <li><a class="ticketbutton" href="https://www.eventbrite.com/e/german-owasp-day-2019-tickets-75721991515">Tickets</a></li>
+          <li><a class="ticketbutton" href="https://www.eventbrite.com/e/german-owasp-day-2019-karlsruhe-tickets-82951101979">Tickets</a></li>
           <li><a href="https://github.com/OWASP/german-owasp-day"><img class="social img-responsive" src="/img/icons/github.png"></a></li>
         </ul>
       </div><!--/.nav-collapse -->
@@ -69,7 +69,7 @@
       <big>OWASP Mitglieder: 199 €</big>
     </p>
 
-    <p>Die Tickets lassen sich <a href="https://www.eventbrite.com/e/german-owasp-day-2019-tickets-75721991515">hier unter Eventbrite kaufen</a>.</p>
+    <p>Die Tickets lassen sich <a href="https://www.eventbrite.com/e/german-owasp-day-2019-karlsruhe-tickets-82951101979">hier unter Eventbrite kaufen</a>.</p>
 
 
   <footer class="bd-footer text-muted">


### PR DESCRIPTION
the payment processor in the old event only allowed payment via
paypal. in order to switch payment processors, we unfortunately
also needed to migrate to a new event.
the old event remains active, but available ticket numbers reduced, etc.