### PR TITLE
Remove obsolete sentence and make link visible

### DIFF
--- a/2024/program-detail.html
+++ b/2024/program-detail.html
@@ -508,9 +508,7 @@
                           <p>In early 2024, hundreds of DKIM setups still used cryptographic keys vulnerable to a bug from 2008 in Debian's OpenSSL package. Vulnerable hosts included prominent names like Cisco, Oracle, Skype, and Github.</p>
                           <p>In 2022, it was discovered that printers generated TLS keys that could be trivially broken with an over 300-year-old algorithm by Pierre de Fermat.
                           </p>
-                          <p>Vulnerabilities in public/private key generation are amongst the most severe ones in cryptographic software. The speaker has developed the open-source tool <a href="https://badkeys.info/">badkeys</a>, a tool to check cryptographic keys for known vulnerabilities. The talk will cover some of the findings and plans for future improvements in badkeys.
-                          </p>
-                          <p>Um diese und andere Sicherheitsprobleme mit kompromittierten kryptographischen Schlüsseln, sowie einige Pläne für die Zukunft von badkeys, soll es im Vortrag gehen.
+                          <p>Vulnerabilities in public/private key generation are amongst the most severe ones in cryptographic software. The speaker has developed the open-source tool <a href="https://badkeys.info/" class="speaker-link">badkeys</a>, a tool to check cryptographic keys for known vulnerabilities. The talk will cover some of the findings and plans for future improvements in badkeys.
                           </p>
                         </div>
                         <div class="tab-pane" id="acc-11-simple-tabpanel-1" role="tabpanel" aria-labelledby="acc-11-simple-tab-1">


### PR DESCRIPTION
There was a leftover sentence from the previous (German) talk description. Also, the link was not visible (white on white), using the speaker-link css property that is also used on the start page in areas that have a white background.